### PR TITLE
Dlang-like class invariant checks

### DIFF
--- a/include/god_adapter/invariant.h
+++ b/include/god_adapter/invariant.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <boost/scope_exit.hpp>
+
+#include "decl.h"
+
+// Dlang-like class invariant checks (https://dlang.org/spec/contracts.html#Invariants)
+// TODO: function pre/post-conditions (adaptor modification needed)
+
+template<typename T>
+struct BaseInvariantChecker : T
+{
+    BaseInvariantChecker()
+    {
+		this->invariant();
+    }
+
+    BaseInvariantChecker (BaseInvariantChecker&& other) : T (std::move (other))
+	{
+		this->invariant();
+		other.invariant();
+	}
+
+	BaseInvariantChecker (const BaseInvariantChecker& other) : T (other)
+	{
+		this->invariant();
+		other.invariant();
+	}
+
+    template<typename... V>
+	BaseInvariantChecker(V&&... v) : T(std::forward<V>(v)...)
+	{
+		this->invariant();
+	}
+
+	~BaseInvariantChecker()
+	{
+		this->invariant();
+	}
+
+protected:
+    template<typename F, typename... V>
+    auto call(F f, V&&... v)
+    {
+		this->invariant();
+		BOOST_SCOPE_EXIT_TPL (this_)
+		{
+			this_->invariant();
+		} BOOST_SCOPE_EXIT_END
+
+        return f(*this, std::forward<V>(v)...);
+    }
+};
+
+template<typename T, typename T_base = T>
+using AdaptedChecked = Adapter<T, BaseInvariantChecker<T_base>>;
+

--- a/include/god_adapter/invariant.h
+++ b/include/god_adapter/invariant.h
@@ -5,48 +5,36 @@
 #include "decl.h"
 
 // Dlang-like class invariant checks (https://dlang.org/spec/contracts.html#Invariants)
-// TODO: function pre/post-conditions (adaptor modification needed)
 
 template<typename T>
 struct BaseInvariantChecker : T
 {
-    BaseInvariantChecker()
+    BaseInvariantChecker (BaseInvariantChecker&& other):T (std::move (other))
     {
-		this->invariant();
+        this->invariant();
+        other.invariant();
     }
 
-    BaseInvariantChecker (BaseInvariantChecker&& other) : T (std::move (other))
-	{
-		this->invariant();
-		other.invariant();
-	}
-
-	BaseInvariantChecker (const BaseInvariantChecker& other) : T (other)
-	{
-		this->invariant();
-		other.invariant();
-	}
-
     template<typename... V>
-	BaseInvariantChecker(V&&... v) : T(std::forward<V>(v)...)
-	{
-		this->invariant();
-	}
+    BaseInvariantChecker (V&&... v):T(std::forward<V>(v)...)
+    {
+        this->invariant();
+    }
 
-	~BaseInvariantChecker()
-	{
-		this->invariant();
-	}
+    ~BaseInvariantChecker()
+    {
+        this->invariant();
+    }
 
 protected:
     template<typename F, typename... V>
-    auto call(F f, V&&... v)
+    auto call (F f, V&&... v)
     {
-		this->invariant();
-		BOOST_SCOPE_EXIT_TPL (this_)
-		{
-			this_->invariant();
-		} BOOST_SCOPE_EXIT_END
+        this->invariant();
+        BOOST_SCOPE_EXIT_TPL (this_)
+        {
+            this_->invariant();
+        } BOOST_SCOPE_EXIT_END
 
         return f(*this, std::forward<V>(v)...);
     }

--- a/tests/invariant.cpp
+++ b/tests/invariant.cpp
@@ -2,7 +2,7 @@
 
 #include <god_adapter/invariant.h>
 
-const char* const c_assert = "assert";
+const char* const c_invariant = "invariant";
 
 const char* const c_ctor = "ctor";
 const char* const c_mtor = "mtor";
@@ -36,7 +36,7 @@ public:
 protected:
 	void invariant()
 	{
-		op (c_assert);
+		op (c_invariant);
 	}
 };
 
@@ -48,26 +48,26 @@ BOOST_AUTO_TEST_CASE(Method)
 {
 	{
 		AdaptedChecked<Logic> logic;
-		CHECK_OPS (c_ctor, c_assert);
+		CHECK_OPS (c_ctor, c_invariant);
 
 		logic.method();
-		CHECK_OPS (c_ctor, c_assert, c_assert, c_method, c_assert);
+		CHECK_OPS (c_ctor, c_invariant, c_invariant, c_method, c_invariant);
 	}
 
-	CHECK_OPS (c_ctor, c_assert, c_assert, c_method, c_assert, c_assert, c_dtor);
+	CHECK_OPS (c_ctor, c_invariant, c_invariant, c_method, c_invariant, c_invariant, c_dtor);
 }
 
 BOOST_AUTO_TEST_CASE(MoveCtor)
 {
 	{
 		AdaptedChecked<Logic> logic1;
-		CHECK_OPS (c_ctor, c_assert);
+		CHECK_OPS (c_ctor, c_invariant);
 
 		AdaptedChecked<Logic> logic2 = std::move (logic1);
-		CHECK_OPS (c_ctor, c_assert, c_mtor, c_assert, c_assert);
+		CHECK_OPS (c_ctor, c_invariant, c_mtor, c_invariant, c_invariant);
 	}
 
-	CHECK_OPS (c_ctor, c_assert, c_mtor, c_assert, c_assert, c_assert, c_dtor, c_assert, c_dtor);
+	CHECK_OPS (c_ctor, c_invariant, c_mtor, c_invariant, c_invariant, c_invariant, c_dtor, c_invariant, c_dtor);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/invariant.cpp
+++ b/tests/invariant.cpp
@@ -12,32 +12,32 @@ const char* const c_method = "meth";
 
 struct Logic
 {
-	Logic()
+    Logic()
     {
         op (c_ctor);
     }
 
-	Logic(Logic&&)
-	{
-		op (c_mtor);
-	}
+    Logic(Logic&&)
+    {
+        op (c_mtor);
+    }
 
-	~Logic()
-	{
-		op (c_dtor);
-	}
+    ~Logic()
+    {
+        op (c_dtor);
+    }
 
 public:
-	void method()
-	{
-		op (c_method);
-	}
+    void method()
+    {
+        op (c_method);
+    }
 
 protected:
-	void invariant()
-	{
-		op (c_invariant);
-	}
+    void invariant()
+    {
+        op (c_invariant);
+    }
 };
 
 DECL_ADAPTER (Logic, method)
@@ -46,28 +46,28 @@ BOOST_FIXTURE_TEST_SUITE(invariant, OpsFixture)
 
 BOOST_AUTO_TEST_CASE(Method)
 {
-	{
-		AdaptedChecked<Logic> logic;
-		CHECK_OPS (c_ctor, c_invariant);
+    {
+        AdaptedChecked<Logic> logic;
+        CHECK_OPS (c_ctor, c_invariant);
 
-		logic.method();
-		CHECK_OPS (c_ctor, c_invariant, c_invariant, c_method, c_invariant);
-	}
+        logic.method();
+        CHECK_OPS (c_ctor, c_invariant, c_invariant, c_method, c_invariant);
+    }
 
-	CHECK_OPS (c_ctor, c_invariant, c_invariant, c_method, c_invariant, c_invariant, c_dtor);
+    CHECK_OPS (c_ctor, c_invariant, c_invariant, c_method, c_invariant, c_invariant, c_dtor);
 }
 
 BOOST_AUTO_TEST_CASE(MoveCtor)
 {
-	{
-		AdaptedChecked<Logic> logic1;
-		CHECK_OPS (c_ctor, c_invariant);
+    {
+        AdaptedChecked<Logic> logic1;
+        CHECK_OPS (c_ctor, c_invariant);
 
-		AdaptedChecked<Logic> logic2 = std::move (logic1);
-		CHECK_OPS (c_ctor, c_invariant, c_mtor, c_invariant, c_invariant);
-	}
+        AdaptedChecked<Logic> logic2 = std::move (logic1);
+        CHECK_OPS (c_ctor, c_invariant, c_mtor, c_invariant, c_invariant);
+    }
 
-	CHECK_OPS (c_ctor, c_invariant, c_mtor, c_invariant, c_invariant, c_invariant, c_dtor, c_invariant, c_dtor);
+    CHECK_OPS (c_ctor, c_invariant, c_mtor, c_invariant, c_invariant, c_invariant, c_dtor, c_invariant, c_dtor);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/invariant.cpp
+++ b/tests/invariant.cpp
@@ -1,0 +1,73 @@
+#include "ut.h"
+
+#include <god_adapter/invariant.h>
+
+const char* const c_assert = "assert";
+
+const char* const c_ctor = "ctor";
+const char* const c_mtor = "mtor";
+const char* const c_dtor = "dtor";
+
+const char* const c_method = "meth";
+
+struct Logic
+{
+	Logic()
+    {
+        op (c_ctor);
+    }
+
+	Logic(Logic&&)
+	{
+		op (c_mtor);
+	}
+
+	~Logic()
+	{
+		op (c_dtor);
+	}
+
+public:
+	void method()
+	{
+		op (c_method);
+	}
+
+protected:
+	void invariant()
+	{
+		op (c_assert);
+	}
+};
+
+DECL_ADAPTER (Logic, method)
+
+BOOST_FIXTURE_TEST_SUITE(invariant, OpsFixture)
+
+BOOST_AUTO_TEST_CASE(Method)
+{
+	{
+		AdaptedChecked<Logic> logic;
+		CHECK_OPS (c_ctor, c_assert);
+
+		logic.method();
+		CHECK_OPS (c_ctor, c_assert, c_assert, c_method, c_assert);
+	}
+
+	CHECK_OPS (c_ctor, c_assert, c_assert, c_method, c_assert, c_assert, c_dtor);
+}
+
+BOOST_AUTO_TEST_CASE(MoveCtor)
+{
+	{
+		AdaptedChecked<Logic> logic1;
+		CHECK_OPS (c_ctor, c_assert);
+
+		AdaptedChecked<Logic> logic2 = std::move (logic1);
+		CHECK_OPS (c_ctor, c_assert, c_mtor, c_assert, c_assert);
+	}
+
+	CHECK_OPS (c_ctor, c_assert, c_mtor, c_assert, c_assert, c_assert, c_dtor, c_assert, c_dtor);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Пришёл в голову ещё один пример использования божественного адаптера - проверка инварианта класса как в Dlang:
https://dlang.org/spec/contracts.html#Invariants

Причём она даже привосходит оригинал - если у них нелья при проверке инварианта использовать вызовы, приводящие к проверке инварианта, то тут можно!